### PR TITLE
Transaction list container refactor

### DIFF
--- a/sampleData.js
+++ b/sampleData.js
@@ -1,4 +1,4 @@
-const sampleData = [
+export const sampleData = [
   {
     "metadata": {
       "url": "/",
@@ -354,4 +354,3 @@ const sampleData = [
 ]
 
 
-module.exports = sampleData;

--- a/src/client/components/DetailsTransactionSummary.jsx
+++ b/src/client/components/DetailsTransactionSummary.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
 const DetailsTransactionSummary = ({ selectedTransaction }) => {
+  if (!selectedTransaction) return (
+    <div>State is Empty. Try Again Later.</div>
+  )
   const flags = selectedTransaction.metadata.flags.map(flag => {
     return (
       flag

--- a/src/client/components/TransactionFilterBar.jsx
+++ b/src/client/components/TransactionFilterBar.jsx
@@ -16,12 +16,12 @@ const TransactionFilterBar = props => (
       </select>
     </div>
     <div id='domain-filter'>
-      <span 
-        onClick={() => props.onDomainClick(false)}
-      >Internal</span>
-      <span 
-        onClick={() => props.onDomainClick(true)}
-        >External</span>
+      <span onClick={() => props.onDomainClick(false)}>
+        Internal
+      </span>
+      <span onClick={() => props.onDomainClick(true)}>
+        External
+      </span>
     </div>
     <div id='flag=filter'>
       {flags.map(flag => {

--- a/src/client/components/TransactionItem.jsx
+++ b/src/client/components/TransactionItem.jsx
@@ -9,16 +9,21 @@ const methodStyle = {
   borderRight: '1px solid black',
   width: '75px'
 }
-const TransactionItem = props => (
-  <div className="flex-row" style={itemStyle}>
+const TransactionItem = props => {
+
+  const {id, onTransactionClick, method, url, isExternal, flags } = props;
+
+  return (
+  <div className="flex-row" style={itemStyle} id={id} onClick={() => onTransactionClick(id)}>
     <div className="transaction-item-method" style={methodStyle}>
-    <h4>{props.method}</h4>
+      <h4>{method}</h4>
     </div>
     <div className="transaction-item-endpoint">
-    <p>{props.url}</p>
-    {props.isExternal} <span>{props.flags}</span>
+      <p>{url}</p>
+      {isExternal} <span>{flags}</span>
     </div>
   </div>
-);
 
+  )
+}
 export default TransactionItem;

--- a/src/client/components/TransactionList.jsx
+++ b/src/client/components/TransactionList.jsx
@@ -5,11 +5,13 @@ const TransactionList = props => {
   const list = props.transactions.map((trans, index) => {
     return (
       <TransactionItem 
-      method={trans.metadata.method}
-      url={trans.metadata.url}
-      isExternal={trans.metadata.external ? 'External' : 'Internal'}
-      flags={trans.metadata.flags.join(' ')}
-      key={`trans${index}`}
+        method={trans.metadata.method}
+        url={trans.metadata.url}
+        isExternal={trans.metadata.external ? 'External' : 'Internal'}
+        flags={trans.metadata.flags.join(' ')}
+        key={`trans${index}`}
+        id={trans.id}
+        onTransactionClick={props.onTransactionClick} 
       />
     )
   })

--- a/src/client/components/TransactionList.jsx
+++ b/src/client/components/TransactionList.jsx
@@ -10,7 +10,6 @@ const TransactionList = props => {
       isExternal={trans.metadata.external ? 'External' : 'Internal'}
       flags={trans.metadata.flags.join(' ')}
       key={`trans${index}`}
-      index={index}
       />
     )
   })

--- a/src/client/containers/DetailsRequestContainer.jsx
+++ b/src/client/containers/DetailsRequestContainer.jsx
@@ -17,6 +17,9 @@ class DetailsRequestContainer extends Component {
   }
 
   render() {
+    if (this.props.transactions.length === 0) return (
+      <div>State is empty. Try again later</div>
+    )
     return (
     <div className='flex-column' id='details-request-container'>
       <div id='request'>

--- a/src/client/containers/TransactionListContainer.jsx
+++ b/src/client/containers/TransactionListContainer.jsx
@@ -19,7 +19,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   // fix selectTransaction to include some sort of permanent id property for all the transactions
- selectTransaction: id => dispatch(actions.selectTransaction(id)),
+ onTransactionClick: id => dispatch(actions.selectTransaction(id)),
  onMethodClick: method => dispatch(actions.setTransactionMethodFilter(method)),
  onDomainClick: domain => dispatch(actions.setTransactionDomain(domain)),
  onFlagClick: flag => dispatch(actions.toggleTransactionFlag(flag))
@@ -38,6 +38,7 @@ class TransactionListContainer extends Component {
       transactionMethodFilter,
       transactionFlagFilter,
       transactionDomainFilter,
+      onTransactionClick,
       onMethodClick,
       onDomainClick,
       onFlagClick
@@ -70,11 +71,14 @@ class TransactionListContainer extends Component {
     return (
       <div className='flex-column' id='transaction-list-container'>
         <TransactionFilterBar 
-        onMethodClick={onMethodClick}
-        onDomainClick={onDomainClick}
-        onFlagClick={onFlagClick}
+          onMethodClick={onMethodClick}
+          onDomainClick={onDomainClick}
+          onFlagClick={onFlagClick}
         />
-        <TransactionList transactions={filter(transactions)}/>
+        <TransactionList 
+          transactions={filter(transactions)} 
+          onTransactionClick={onTransactionClick} 
+        />
       </div>
     )
   }

--- a/src/client/reducers/transactionsReducer.js
+++ b/src/client/reducers/transactionsReducer.js
@@ -1,4 +1,5 @@
-const sampleData = require('../../../sampleData');
+
+import { sampleData } from '../../../sampleData';
 import * as types from '../constants/actionTypes';
 
 

--- a/src/client/reducers/transactionsReducer.js
+++ b/src/client/reducers/transactionsReducer.js
@@ -2,11 +2,19 @@
 import { sampleData } from '../../../sampleData';
 import * as types from '../constants/actionTypes';
 
+let nextTransactionId = 0;
 
-export const transactions = (state = sampleData, action) => {
+const addIndex = object => ({
+  ...object, 
+  id: nextTransactionId++
+});
+
+
+export const transactions = (state = [], action) => {
   switch  (action.type) {
     case types.ADD_TRANSACTION: 
-      return [...state, action.payload]
+      const incoming = action.payload.map(trans => addIndex(trans))
+      return [...state, ...incoming]
     default:
       return state;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ import ReactDOM from "react-dom";
 import { Provider } from 'react-redux';
 import App from "./App.js";
 import store from './client/store';
+import { addTransaction } from "./client/actions/actions.js";
+import { sampleData } from "../sampleData.js";
 
 console.log('hello!');
 ReactDOM.render(
@@ -11,3 +13,5 @@ ReactDOM.render(
   </Provider>,
     document.getElementById("root")
 );
+
+store.dispatch(addTransaction(sampleData));


### PR DESCRIPTION
## Details Side
* refactored details containers to not break on render when initial state is empty; getting ready to remove sample data training wheels 

## Transaction List Side 
* refactored reducer to add an array of transaction objects to state
* added an ID property to every incoming transaction object, via reducer 
* added 'click to see details' behavior to transaction list 
* all behavior should be complete, pending refactoring and cleaning 

## index.js 
* added a dummy dispatch call to add transactions from sample data to test new reducer format and still populate state, but not as initial state now. 